### PR TITLE
Upgrade Elasticsearch to version 5.6.0.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/pires/docker-elasticsearch:5.6.0
+FROM quay.io/pires/docker-elasticsearch:5.6.1
 
 MAINTAINER pjpires@gmail.com
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/pires/docker-elasticsearch:5.6.2
+FROM quay.io/pires/docker-elasticsearch:5.6.3
 
 MAINTAINER pjpires@gmail.com
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/pires/docker-elasticsearch:5.6.1
+FROM quay.io/pires/docker-elasticsearch:5.6.2
 
 MAINTAINER pjpires@gmail.com
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/pires/docker-elasticsearch:5.5.2
+FROM quay.io/pires/docker-elasticsearch:5.6.0
 
 MAINTAINER pjpires@gmail.com
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Ready to use, lean Elasticsearch Docker image ready for using within a Kubernete
 ## Current software
 
 * OpenJDK JRE 8u131
-* Elasticsearch 5.5.2
+* Elasticsearch 5.6.0
 
 ## Run
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Ready to use, lean Elasticsearch Docker image ready for using within a Kubernete
 ## Current software
 
 * OpenJDK JRE 8u131
-* Elasticsearch 5.6.2
+* Elasticsearch 5.6.3
 
 ## Run
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Ready to use, lean Elasticsearch Docker image ready for using within a Kubernete
 ## Current software
 
 * OpenJDK JRE 8u131
-* Elasticsearch 5.6.0
+* Elasticsearch 5.6.1
 
 ## Run
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Ready to use, lean Elasticsearch Docker image ready for using within a Kubernete
 ## Current software
 
 * OpenJDK JRE 8u131
-* Elasticsearch 5.6.1
+* Elasticsearch 5.6.2
 
 ## Run
 


### PR DESCRIPTION
Signed-off-by: Paulo Pires <pjpires@gmail.com>